### PR TITLE
Update prefs.js add 5 minutes value

### DIFF
--- a/unblank@sun.wxg@gmail.com/prefs.js
+++ b/unblank@sun.wxg@gmail.com/prefs.js
@@ -47,6 +47,7 @@ function buildPrefsWidget() {
                              (box) => { gsettings.set_int('time', Number(box.get_active_id())) });
 
     timebox_comboBox.append("0", "Never");
+    timebox_comboBox.append("300", "5 minutes");
     timebox_comboBox.append("1800", "30 minutes");
     timebox_comboBox.append("3600", "60 minutes");
     timebox_comboBox.append("5400", "90 minutes");


### PR DESCRIPTION
I need to use 5 minutes because 30 minutes is too long. I have a wireless keyboard and mouse and I block the screen and put them away from the table. If you do not use the extension, then the screen wakes up from an accidental press, and half an hour is too much. One minute would have been enough for me, but this is already too ugly for me, so please make 5 minutes - it will just be like turning off the instant screen off. I do this at home, but the auto-update of the extension spoils it. Thanks a lot!